### PR TITLE
Release 0.2-beta_20220317

### DIFF
--- a/src/main/java/com/stargazerstudios/existence/conductor/constants/EnumRank.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/constants/EnumRank.java
@@ -1,0 +1,19 @@
+package com.stargazerstudios.existence.conductor.constants;
+
+public enum EnumRank {
+    ROLE_OWNER(0),
+    ROLE_SUPERUSER(1),
+    ROLE_ADMIN(2),
+    ROLE_USER(3),
+    ROLE_BANNED(1000);
+
+    private final long value;
+
+    EnumRank(long value) {
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/constants/EnumUtilNumberOutput.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/constants/EnumUtilNumberOutput.java
@@ -1,0 +1,16 @@
+package com.stargazerstudios.existence.conductor.constants;
+
+public enum EnumUtilNumberOutput {
+    INVALID(20292),
+    EMPTY(113091);
+
+    private final int value;
+
+    EnumUtilNumberOutput(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/controller/ExistenceController.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/controller/ExistenceController.java
@@ -22,12 +22,18 @@ public class ExistenceController {
 
     @GetMapping("/dreams")
     public ResponseEntity<ExistenceIdentity> announceExistence() throws FatalErrorException {
-        return new ResponseEntity<>(existenceService.realizeDreams(), HttpStatus.OK);
+        return new ResponseEntity<>(existenceService.instigate(), HttpStatus.OK);
     }
 
-    @PostMapping("/restart")
+    @PostMapping("/reset-password")
     public ResponseEntity<UserDTO> resetAdminPassword(@RequestBody UserWrapper user)
             throws FatalErrorException, UserUnauthorizedException, InvalidPropertyErrorException {
-        return new ResponseEntity<>(existenceService.startOver(user), HttpStatus.OK);
+        return new ResponseEntity<>(existenceService.resetAdminPassword(user), HttpStatus.OK);
+    }
+
+    @PostMapping("/reset-roles")
+    public ResponseEntity<UserDTO> resetAdminRoles(@RequestBody UserWrapper user)
+            throws FatalErrorException, InvalidPropertyErrorException, UserUnauthorizedException {
+        return new ResponseEntity<>(existenceService.resetAdminRoles(user), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/conductor/erratum/universal/DatabaseErrorException.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/erratum/universal/DatabaseErrorException.java
@@ -9,6 +9,6 @@ public class DatabaseErrorException extends Exception{
     }
 
     public HttpStatus getHttpStatus() {
-        return HttpStatus.CONFLICT;
+        return HttpStatus.INTERNAL_SERVER_ERROR;
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/conductor/erratum/universal/EntitySaveErrorException.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/erratum/universal/EntitySaveErrorException.java
@@ -1,0 +1,8 @@
+package com.stargazerstudios.existence.conductor.erratum.universal;
+
+public class EntitySaveErrorException extends DatabaseErrorException {
+
+    public EntitySaveErrorException(String entityName) {
+        super("There is an error while saving the " + entityName + ".");
+    }
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/erratum/universal/GenericErrorException.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/erratum/universal/GenericErrorException.java
@@ -9,6 +9,6 @@ public class GenericErrorException extends Exception{
     }
 
     public HttpStatus getHttpStatus() {
-        return HttpStatus.PAYMENT_REQUIRED;
+        return HttpStatus.BAD_REQUEST;
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/conductor/service/ExistenceService.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/service/ExistenceService.java
@@ -8,7 +8,9 @@ import com.stargazerstudios.existence.conductor.erratum.universal.UserUnauthoriz
 import com.stargazerstudios.existence.conductor.model.ExistenceIdentity;
 import com.stargazerstudios.existence.conductor.utils.StringUtil;
 import com.stargazerstudios.existence.symphony.dto.UserDTO;
+import com.stargazerstudios.existence.symphony.entity.Role;
 import com.stargazerstudios.existence.symphony.entity.User;
+import com.stargazerstudios.existence.symphony.repository.RoleDAO;
 import com.stargazerstudios.existence.symphony.repository.UserDAO;
 import com.stargazerstudios.existence.symphony.utils.UserUtil;
 import com.stargazerstudios.existence.symphony.wrapper.UserWrapper;
@@ -18,7 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @Transactional
@@ -26,6 +28,9 @@ public class ExistenceService {
 
     @Autowired
     private UserDAO userDAO;
+
+    @Autowired
+    private RoleDAO roleDAO;
 
     @Autowired
     private UserUtil userUtil;
@@ -39,11 +44,11 @@ public class ExistenceService {
     @Value("${master.password}")
     private String masterPassword;
 
-    public ExistenceIdentity realizeDreams() {
+    public ExistenceIdentity instigate() {
         return new ExistenceIdentity();
     }
 
-    public UserDTO startOver(UserWrapper wUser)
+    public UserDTO resetAdminPassword(UserWrapper wUser)
             throws UserUnauthorizedException, FatalErrorException, InvalidPropertyErrorException {
         String username = stringUtil.checkInput(wUser.getUsername());
         String password = stringUtil.checkInput(wUser.getPassword());
@@ -64,6 +69,50 @@ public class ExistenceService {
         String hashPassword = passwordEncoder.encode(EnumAuthorization.DEFAULT_USER.getValue());
         admin.setPassword(hashPassword);
 
+        try {
+            userDAO.save(admin);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new FatalErrorException();
+        }
+
+        return userUtil.wrapUser(admin);
+    }
+
+    public UserDTO resetAdminRoles(UserWrapper wUser)
+            throws UserUnauthorizedException, FatalErrorException, InvalidPropertyErrorException {
+        String username = stringUtil.checkInput(wUser.getUsername());
+        String password = stringUtil.checkInput(wUser.getPassword());
+
+        if (!username.equals(EnumAuthorization.DEFAULT_USER.getValue())) throw new UserUnauthorizedException();
+        if (username.equals(EnumUtilOutput.EMPTY.getValue())) throw new UserUnauthorizedException();
+        if (password.equals(EnumUtilOutput.EMPTY.getValue())) throw new UserUnauthorizedException();
+
+        if (stringUtil.checkInput(masterPassword).equals(EnumUtilOutput.EMPTY.getValue()))
+            throw new InvalidPropertyErrorException("master.password");
+
+        if (!password.equals(masterPassword)) throw new UserUnauthorizedException();
+
+        Optional<User> adminData = userDAO.findByUsername(username);
+        if (adminData.isEmpty()) throw new FatalErrorException();
+
+        User admin = adminData.get();
+        Set<String> roleNames = new HashSet<>(Arrays.asList(
+                EnumAuthorization.OWNER.getValue(),
+                EnumAuthorization.SUPERUSER.getValue(),
+                EnumAuthorization.ADMIN.getValue(),
+                EnumAuthorization.USER.getValue()
+        ));
+
+        List<Role> dbRoles = roleDAO.findRolesBySet(roleNames);
+        try {
+            if (dbRoles.size() != roleNames.size()) throw new FatalErrorException();
+        } catch (FatalErrorException e) {
+            e.printStackTrace();
+        }
+
+        Set<Role> roles = new HashSet<>(dbRoles);
+        admin.setRoles(roles);
         try {
             userDAO.save(admin);
         } catch (Exception e) {

--- a/src/main/java/com/stargazerstudios/existence/conductor/startup/Initializer.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/startup/Initializer.java
@@ -1,7 +1,9 @@
 package com.stargazerstudios.existence.conductor.startup;
 
 import com.stargazerstudios.existence.conductor.constants.EnumAuthorization;
+import com.stargazerstudios.existence.conductor.constants.EnumRank;
 import com.stargazerstudios.existence.conductor.constants.EnumUtilOutput;
+import com.stargazerstudios.existence.conductor.erratum.universal.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.universal.FatalErrorException;
 import com.stargazerstudios.existence.conductor.erratum.universal.InvalidPropertyErrorException;
 import com.stargazerstudios.existence.conductor.utils.StringUtil;
@@ -36,13 +38,22 @@ public class Initializer {
     @Value("${jwt.secret}")
     private String jwtKey;
 
+    /**
+     * Automatically executed upon application startup.
+     * It calls methods that validate integral parts of the app.
+     */
     @EventListener(ApplicationReadyEvent.class)
-    public void postStartUp() throws FatalErrorException, InvalidPropertyErrorException {
-        createDefaultAdmin();
+    private void postStartUp() {
+        checkDefaultAdmin();
         checkJwtKey();
+        checkRoles();
     }
 
-    private void createDefaultAdmin() throws FatalErrorException {
+    /**
+     * Checks if the default admin account has been set up. If no admin account is found, it automatically creates
+     * one and grants it maximum authority.
+     */
+    private void checkDefaultAdmin() {
         Optional<User> adminData = userDAO.findByUsername(EnumAuthorization.DEFAULT_USER.getValue());
         if (adminData.isEmpty()) {
             User admin = new User();
@@ -75,11 +86,52 @@ public class Initializer {
         }
     }
 
-    private void checkJwtKey() throws InvalidPropertyErrorException {
+    /**
+     * Checks if the property "jwt.secret" has been defined on the application.properties file.
+     * If not, this throws an error that is readable on the system logs.
+     */
+    private void checkJwtKey() {
         try {
             if (stringUtil.checkInput(jwtKey).equals(EnumUtilOutput.EMPTY.getValue()))
                 throw new InvalidPropertyErrorException("jwt.secret");
         } catch (InvalidPropertyErrorException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Checks the integrity of the roles saved in the database. If it finds a discrepancy, it throws an error
+     * that is readable on the system logs.
+     */
+    private void checkRoles() {
+        Set<String> roleNames = new HashSet<>();
+        for (EnumAuthorization auth: EnumAuthorization.values()) {
+            if (!auth.equals(EnumAuthorization.DEFAULT_USER)) roleNames.add(auth.getValue());
+        }
+
+        final List<Role> roles = roleDAO.findRolesBySet(roleNames);
+
+        try {
+            if (roles.size() != roleNames.size()) throw new DatabaseErrorException("The roles database has been tampered with." +
+                    " Please contact an admin.");
+        } catch (DatabaseErrorException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            for (EnumRank rank: EnumRank.values()) {
+                Role role = roles.stream()
+                        .filter(
+                                x -> x.getRank() == rank.getValue()
+                        )
+                        .findAny()
+                        .orElse(null);
+                if (role == null) throw new DatabaseErrorException("The roles database has been tampered with." +
+                            " Please contact an admin.");
+                if (!role.getName().equals(rank.toString())) throw new DatabaseErrorException("The roles database has been tampered with." +
+                        " Please contact an admin.");
+            }
+        } catch (DatabaseErrorException e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/stargazerstudios/existence/conductor/utils/AuthorityUtil.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/utils/AuthorityUtil.java
@@ -1,30 +1,120 @@
 package com.stargazerstudios.existence.conductor.utils;
 
+import com.stargazerstudios.existence.conductor.constants.EnumAuthorization;
+import com.stargazerstudios.existence.conductor.constants.EnumRank;
+import com.stargazerstudios.existence.conductor.constants.EnumUtilNumberOutput;
+import com.stargazerstudios.existence.conductor.constants.EnumUtilOutput;
+import com.stargazerstudios.existence.symphony.entity.Role;
+import com.stargazerstudios.existence.symphony.entity.User;
+import com.stargazerstudios.existence.symphony.repository.RoleDAO;
+import com.stargazerstudios.existence.symphony.repository.UserDAO;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class AuthorityUtil {
 
-    public boolean checkAuthority(String role) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        List<GrantedAuthority> authorities = new ArrayList<>(authentication.getAuthorities());
-        GrantedAuthority authority = authorities.stream()
-                .filter(grantedAuthority ->
-                        role.equals(grantedAuthority.getAuthority()))
-                .findAny()
-                .orElse(null);
+    @Autowired
+    private RoleDAO roleDAO;
 
-        return authority != null;
+    @Autowired
+    private UserDAO userDAO;
+
+    @Autowired
+    private StringUtil stringUtil;
+
+    public boolean checkAuthority(String role) {
+        if (isBanned()) return false;
+
+        String roleName = stringUtil.checkInputTrimToUpper(role);
+        if (roleName.equals(EnumUtilOutput.EMPTY.getValue()) || roleName.equals(EnumUtilOutput.INVALID.getValue()))
+            return false;
+
+        long highestRank = getHighestRank();
+        long inputRank;
+        try {
+            inputRank = EnumRank.valueOf(role).getValue();
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        return highestRank <= inputRank;
     }
 
     public String getAuthUsername() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return authentication.getName();
+    }
+
+    public long getHighestRank() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Optional<User> userData = userDAO.findByUsername(authentication.getName());
+        if (userData.isEmpty()) return EnumUtilNumberOutput.INVALID.getValue();
+
+        User user = userData.get();
+        List<Role> roles = new ArrayList<>(user.getRoles());
+        if (roles.isEmpty()) return EnumUtilNumberOutput.INVALID.getValue();
+
+        roles.sort(Comparator.comparing(Role::getRank));
+        return roles.get(0).getRank();
+    }
+
+    public long getHighestRank(User user) {
+        if (user == null) return EnumUtilNumberOutput.INVALID.getValue();
+
+        List<Role> roles = new ArrayList<>(user.getRoles());
+        if (roles.isEmpty()) return EnumUtilNumberOutput.INVALID.getValue();
+
+        roles.sort(Comparator.comparing(Role::getRank));
+        return roles.get(0).getRank();
+    }
+
+    public long getHighestRank(List<Role> roles) {
+        if (roles.isEmpty()) return EnumUtilNumberOutput.INVALID.getValue();
+
+        roles.sort(Comparator.comparing(Role::getRank));
+        return roles.get(0).getRank();
+    }
+
+    public boolean hasHigherRank(long checkRank, long compareRank) {
+        return checkRank <= compareRank;
+    }
+
+    public boolean isBanned() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        List<GrantedAuthority> authorities = new ArrayList<>(authentication.getAuthorities());
+        GrantedAuthority authority = authorities.stream()
+                .filter(grantedAuthority ->
+                        EnumAuthorization.BANNED.getValue().equals(grantedAuthority.getAuthority()))
+                .findAny()
+                .orElse(null);
+        return authority != null;
+    }
+
+    public boolean isBanned(Set<Role> roles) {
+        List<Role> roleList = new ArrayList<>(roles);
+        Role role = roleList.stream()
+                .filter(banned ->
+                    EnumAuthorization.BANNED.getValue().equals(banned.getName())
+                )
+                .findAny()
+                .orElse(null);
+        return role != null;
+    }
+
+    public boolean isBanned(List<GrantedAuthority> authorities) {
+        GrantedAuthority authority = authorities.stream()
+                .filter(grantedAuthority ->
+                        EnumAuthorization.BANNED.getValue().equals(grantedAuthority.getAuthority()))
+                .findAny()
+                .orElse(null);
+        return authority != null;
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/controller/AuthenticationController.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/controller/AuthenticationController.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 @CrossOrigin
 @RestController
 @RequestMapping("/concerto/")
@@ -20,7 +23,7 @@ public class AuthenticationController {
     @PostMapping("/login")
     public ResponseEntity<UserDTO> login(@RequestBody UserWrapper user)
             throws UserNotFoundException, BadGatewayException, EntityNotFoundException,
-                InvalidInputException, FatalErrorException, InvalidPropertyErrorException {
+            InvalidInputException, FatalErrorException, InvalidPropertyErrorException, UserUnauthorizedException {
         return new ResponseEntity<>(authenticationService.login(user), HttpStatus.OK);
     }
 
@@ -30,7 +33,7 @@ public class AuthenticationController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Boolean> logout() {
-        return new ResponseEntity<>(true, HttpStatus.OK);
+    public ResponseEntity<Boolean> logout(HttpServletRequest request, HttpServletResponse response) {
+        return new ResponseEntity<>(authenticationService.logout(request, response), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/controller/UserController.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/controller/UserController.java
@@ -32,7 +32,8 @@ public class UserController {
 
     @PostMapping("/user")
     public ResponseEntity<UserDTO> createUser(@RequestBody UserWrapper user)
-            throws InvalidInputException, DuplicateEntityException, UserUnauthorizedException, DatabaseErrorException, EntityNotFoundException {
+            throws InvalidInputException, DuplicateEntityException, UserUnauthorizedException,
+            DatabaseErrorException, EntityNotFoundException {
         return new ResponseEntity<>(userAccessService.createUser(user), HttpStatus.OK);
     }
 
@@ -50,17 +51,26 @@ public class UserController {
 
     @PutMapping("/user/remove-roles")
     public ResponseEntity<UserDTO> removeRoles(@RequestBody UserWrapper user)
-            throws InvalidInputException, EntityNotFoundException, UserUnauthorizedException {
+            throws InvalidInputException, EntityNotFoundException, UserUnauthorizedException,
+                DatabaseErrorException, GenericErrorException {
         return new ResponseEntity<>(userAccessService.removeRoles(user), HttpStatus.OK);
     }
 
     @PutMapping("/user/ban-user")
-    public ResponseEntity<UserDTO> banUser(@RequestBody UserWrapper user) {
-        return null;
+    public ResponseEntity<UserDTO> banUser(@RequestBody UserWrapper user)
+            throws InvalidInputException, EntityNotFoundException, FatalErrorException, UserUnauthorizedException {
+        return new ResponseEntity<>(userAccessService.banUser(user), HttpStatus.OK);
     }
 
     @PutMapping("/user/unban-user")
-    public ResponseEntity<UserDTO> unbanUser(@RequestBody UserWrapper user) {
-        return null;
+    public ResponseEntity<UserDTO> unbanUser(@RequestBody UserWrapper user)
+            throws InvalidInputException, EntityNotFoundException, UserUnauthorizedException, FatalErrorException {
+        return new ResponseEntity<>(userAccessService.unbanUser(user), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/user")
+    public ResponseEntity<UserDTO> deleteUser(@RequestBody UserWrapper user)
+            throws InvalidInputException, EntityNotFoundException, FatalErrorException, UserUnauthorizedException {
+        return new ResponseEntity<>(userAccessService.deleteUser(user), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/entity/Role.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/entity/Role.java
@@ -29,7 +29,7 @@ public class Role {
     @Column(name = "creation_date")
     private Timestamp dateAdded;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "users_roles",
             joinColumns = {

--- a/src/main/java/com/stargazerstudios/existence/symphony/entity/User.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/entity/User.java
@@ -26,7 +26,7 @@ public class User {
     @Column(name = "creation_date")
     private Timestamp dateAdded;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "users_roles",
             joinColumns = {

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/AuthenticationService.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/AuthenticationService.java
@@ -4,8 +4,12 @@ import com.stargazerstudios.existence.conductor.erratum.universal.*;
 import com.stargazerstudios.existence.symphony.dto.UserDTO;
 import com.stargazerstudios.existence.symphony.wrapper.UserWrapper;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 public interface AuthenticationService {
     UserDTO login(UserWrapper user)
-            throws UserNotFoundException, BadGatewayException, EntityNotFoundException, InvalidInputException, FatalErrorException, InvalidPropertyErrorException;
+            throws UserNotFoundException, BadGatewayException, EntityNotFoundException, InvalidInputException, FatalErrorException, InvalidPropertyErrorException, UserUnauthorizedException;
     UserDTO autologin(String token) throws UserNotFoundException;
+    boolean logout(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/RoleServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/RoleServiceImpl.java
@@ -9,14 +9,12 @@ import com.stargazerstudios.existence.symphony.utils.RoleUtil;
 import com.stargazerstudios.existence.symphony.wrapper.RoleWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 @Service
-@Transactional
 public class RoleServiceImpl implements RoleService{
 
     @Autowired

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/UserAccessService.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/UserAccessService.java
@@ -8,19 +8,22 @@ import java.util.List;
 
 public interface UserAccessService {
     List<UserDTO> getAllUsers();
-    UserDTO getUser(UserWrapper user) throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException;
+    UserDTO getUser(UserWrapper user)
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException;
     UserDTO createUser(UserWrapper user)
-            throws DuplicateEntityException, InvalidInputException, UserUnauthorizedException, DatabaseErrorException, EntityNotFoundException;
+            throws DuplicateEntityException, InvalidInputException, UserUnauthorizedException,
+                DatabaseErrorException, EntityNotFoundException;
     UserDTO updateUserPassword(UserWrapper user)
             throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException, DatabaseErrorException;
     UserDTO deleteUser(UserWrapper user)
-            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException;
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException, FatalErrorException;
     UserDTO addRoles(UserWrapper user)
             throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException;
     UserDTO removeRoles(UserWrapper user)
-            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException;
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException,
+                DatabaseErrorException, GenericErrorException;
     UserDTO banUser(UserWrapper user)
-            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException;
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException, FatalErrorException;
     UserDTO unbanUser(UserWrapper user)
-            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException;
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException, FatalErrorException;
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/UserAccessServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/UserAccessServiceImpl.java
@@ -1,6 +1,7 @@
 package com.stargazerstudios.existence.symphony.service;
 
 import com.stargazerstudios.existence.conductor.constants.EnumAuthorization;
+import com.stargazerstudios.existence.conductor.constants.EnumRank;
 import com.stargazerstudios.existence.conductor.constants.EnumUtilOutput;
 import com.stargazerstudios.existence.conductor.erratum.universal.*;
 import com.stargazerstudios.existence.conductor.utils.AuthorityUtil;
@@ -16,13 +17,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 
 @Service
-@Transactional
 public class UserAccessServiceImpl implements UserAccessService{
+    // TODO: Add process to allow superusers to reset and give a new password to lesser users
+    //  or other superusers without knowing their old passwords
 
     @Autowired
     private UserDAO userDAO;
@@ -70,8 +71,8 @@ public class UserAccessServiceImpl implements UserAccessService{
     public UserDTO createUser(UserWrapper wUser)
             throws DuplicateEntityException, InvalidInputException, UserUnauthorizedException,
                 DatabaseErrorException, EntityNotFoundException {
-        boolean isAuthorized = authorityUtil.checkAuthority(EnumAuthorization.SUPERUSER.getValue());
-        if (!isAuthorized) throw new UserUnauthorizedException();
+        long authRank = authorityUtil.getHighestRank();
+        if (authRank > EnumRank.ROLE_SUPERUSER.getValue()) throw new UserUnauthorizedException();
 
         String username = stringUtil.checkInputTrim(wUser.getUsername());
         if (username.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("username");
@@ -109,8 +110,15 @@ public class UserAccessServiceImpl implements UserAccessService{
         String username = stringUtil.checkInputTrim(wUser.getUsername());
         if (username.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("username");
 
-        String password = stringUtil.checkInputTrim(wUser.getPassword());
-        if (password.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("password");
+        String oldPassword = stringUtil.checkInputTrim(wUser.getOld_password());
+        if (oldPassword.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("old_password");
+
+        String newPassword = stringUtil.checkInputTrim(wUser.getNew_password());
+        if (newPassword.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("new_password");
+
+        String confirmPassword = stringUtil.checkInputTrim(wUser.getConfirm_password());
+        if (confirmPassword.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("confirm_password");
+        if (!newPassword.equals(confirmPassword)) throw new InvalidInputException("confirm_password");
 
         String authUsername = authorityUtil.getAuthUsername();
         boolean isAuthorized = authorityUtil.checkAuthority(EnumAuthorization.SUPERUSER.getValue());
@@ -120,23 +128,48 @@ public class UserAccessServiceImpl implements UserAccessService{
         Optional<User> userData = userDAO.findByUsername(username);
         if (userData.isEmpty()) throw new EntityNotFoundException("User with username: " + username + " not found.");
         User user = userData.get();
-        String hashPword = passwordEncoder.encode(password);
-        user.setPassword(hashPword);
+        if (!passwordEncoder.matches(oldPassword, user.getPassword())) throw new InvalidInputException("old_password");
+        if (oldPassword.equals(newPassword)) throw new InvalidInputException("new_password");
+        String hashPassword = passwordEncoder.encode(newPassword);
+        user.setPassword(hashPassword);
 
         try {
             userDAO.save(user);
         } catch (Exception e) {
             e.printStackTrace();
-            throw new DatabaseErrorException("The is a problem saving the changes. Please contact admin.");
+            throw new DatabaseErrorException("The is a problem saving the changes. Please contact an admin.");
         }
 
         return userUtil.wrapUser(user);
     }
 
     @Override
-    public UserDTO deleteUser(UserWrapper user)
-            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException {
-        return null;
+    public UserDTO deleteUser(UserWrapper wUser)
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException, FatalErrorException {
+        boolean isSuperUserOrHigher = authorityUtil.checkAuthority(EnumAuthorization.SUPERUSER.getValue());
+        if (!isSuperUserOrHigher) throw new UserUnauthorizedException();
+
+        String username = stringUtil.checkInputTrim(wUser.getUsername());
+        if (username.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("username");
+
+        String authUsername = authorityUtil.getAuthUsername();
+        if (username.equals(authUsername)) throw new UserUnauthorizedException();
+
+        Optional<User> userData = userDAO.findByUsername(username);
+        if (userData.isEmpty()) throw new EntityNotFoundException("User with username: " + username + " not found.");
+
+        User user = userData.get();
+        long userRank = authorityUtil.getHighestRank(user);
+        long authRank = authorityUtil.getHighestRank();
+        if (authorityUtil.hasHigherRank(userRank, authRank)) throw new UserUnauthorizedException();
+
+        try {
+            userDAO.delete(user);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new FatalErrorException();
+        }
+        return userUtil.wrapUser(user);
     }
 
     @Override
@@ -154,6 +187,16 @@ public class UserAccessServiceImpl implements UserAccessService{
         String[] rolesIn = wUser.getRoles();
         if (rolesIn == null || rolesIn.length == 0) throw new InvalidInputException("roles");
 
+        Optional<User> userData = userDAO.findByUsername(username);
+        if (userData.isEmpty()) throw new EntityNotFoundException("User with username: " + username + " not found.");
+        User user = userData.get();
+
+        if (authorityUtil.isBanned(user.getRoles())) throw new InvalidInputException("username");
+
+        long userRank = authorityUtil.getHighestRank(user);
+        long authRank = authorityUtil.getHighestRank();
+        if (authorityUtil.hasHigherRank(userRank, authRank)) throw new UserUnauthorizedException();
+
         Set<String> rolesQuery = new HashSet<>();
         for (String role: rolesIn) {
             if (!stringUtil.checkInputTrim(role).equals(EnumUtilOutput.EMPTY.getValue())) {
@@ -161,13 +204,12 @@ public class UserAccessServiceImpl implements UserAccessService{
             }
         }
 
-        Optional<User> userData = userDAO.findByUsername(username);
-        if (userData.isEmpty()) throw new EntityNotFoundException("User with username: " + username + " not found.");
-
         List<Role> rolesDb = roleDAO.findRolesBySet(rolesQuery);
         if (rolesDb.size() != rolesQuery.size()) throw new InvalidCollectionException("roles");
 
-        User user = userData.get();
+        long inputRank = authorityUtil.getHighestRank(rolesDb);
+        if (authorityUtil.hasHigherRank(inputRank, authRank)) throw new UserUnauthorizedException();
+
         Set<Role> userRoles = user.getRoles();
         Set<Role> addRoles = new HashSet<>(rolesDb);
         userRoles.addAll(addRoles);
@@ -178,7 +220,8 @@ public class UserAccessServiceImpl implements UserAccessService{
 
     @Override
     public UserDTO removeRoles(UserWrapper wUser)
-            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException {
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException,
+                DatabaseErrorException, GenericErrorException {
         boolean isAuthorized = authorityUtil.checkAuthority(EnumAuthorization.SUPERUSER.getValue());
         if (!isAuthorized) throw new UserUnauthorizedException();
 
@@ -191,6 +234,16 @@ public class UserAccessServiceImpl implements UserAccessService{
         String[] rolesIn = wUser.getRoles();
         if (rolesIn == null || rolesIn.length == 0) throw new InvalidInputException("roles");
 
+        Optional<User> userData = userDAO.findByUsername(username);
+        if (userData.isEmpty()) throw new EntityNotFoundException("User with username: " + username + " not found.");
+        User user = userData.get();
+
+        if (authorityUtil.isBanned(user.getRoles())) throw new InvalidInputException("username");
+
+        long userRank = authorityUtil.getHighestRank(user);
+        long authRank = authorityUtil.getHighestRank();
+        if (authorityUtil.hasHigherRank(userRank, authRank)) throw new UserUnauthorizedException();
+
         Set<String> rolesQuery = new HashSet<>();
         for (String role: rolesIn) {
             if (!stringUtil.checkInputTrim(role).equals(EnumUtilOutput.EMPTY.getValue())) {
@@ -198,30 +251,102 @@ public class UserAccessServiceImpl implements UserAccessService{
             }
         }
 
-        Optional<User> userData = userDAO.findByUsername(username);
-        if (userData.isEmpty()) throw new EntityNotFoundException("User with username: " + username + " not found.");
-
-        List<Role> rolesDb = roleDAO.findRolesBySet(rolesQuery);
-        if (rolesDb.size() != rolesQuery.size()) throw new InvalidCollectionException("roles");
-
-        User user = userData.get();
         Set<Role> userRoles = user.getRoles();
-        Set<Role> removeRoles = new HashSet<>(rolesDb);
+
+        Set<Role> removeRoles = new HashSet<>();
+        List<Role> userRoleList = new ArrayList<>(userRoles);
+        for (String roleName: rolesQuery) {
+            Role result = userRoleList.stream()
+                    .filter(role ->
+                        roleName.equals(role.getName())
+                    )
+                    .findAny()
+                    .orElse(null);
+            if (result != null) {
+                removeRoles.add(result);
+            } else {
+                throw new  GenericErrorException("User does not have the role: " + roleName + ".");
+            }
+        }
+
         userRoles.removeAll(removeRoles);
+        if (userRoles.size() == 1) throw new GenericErrorException("User should have at least one role.");
 
         user.setRoles(userRoles);
-        return userUtil.wrapUser(userDAO.save(user));
+
+        try {
+            userDAO.save(user);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new EntitySaveErrorException("user");
+        }
+
+        return userUtil.wrapUser(user);
     }
 
     @Override
-    public UserDTO banUser(UserWrapper user)
-            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException {
-        return null;
+    public UserDTO banUser(UserWrapper wUser)
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException, FatalErrorException {
+        String username = stringUtil.checkInputTrim(wUser.getUsername());
+        if (username.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("username");
+
+        String authUsername = authorityUtil.getAuthUsername();
+        if (username.equals(authUsername)) throw new UserUnauthorizedException();
+
+        Optional<User> userData = userDAO.findByUsername(username);
+        if (userData.isEmpty()) throw new EntityNotFoundException("User with username: " + username + " not found.");
+        User user = userData.get();
+
+        boolean isBanned = authorityUtil.isBanned(user.getRoles());
+        if (isBanned) throw new InvalidInputException("username"); // TODO: This must be more specific.
+
+        Optional<Role> banData = roleDAO.findByName(EnumAuthorization.BANNED.getValue());
+        if (banData.isEmpty()) throw new FatalErrorException();
+
+        Set<Role> roles = new HashSet<>();
+        Role ban = banData.get();
+        roles.add(ban);
+        user.setRoles(roles);
+
+        try {
+            userDAO.save(user);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new FatalErrorException();
+        }
+        return userUtil.wrapUser(user);
     }
 
     @Override
-    public UserDTO unbanUser(UserWrapper user)
-            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException {
-        return null;
+    public UserDTO unbanUser(UserWrapper wUser)
+            throws EntityNotFoundException, InvalidInputException, UserUnauthorizedException, FatalErrorException {
+        String username = stringUtil.checkInputTrim(wUser.getUsername());
+        if (username.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("username");
+
+        String authUsername = authorityUtil.getAuthUsername();
+        if (username.equals(authUsername)) throw new UserUnauthorizedException();
+
+        Optional<User> userData = userDAO.findByUsername(username);
+        if (userData.isEmpty()) throw new EntityNotFoundException("User with username: " + username + " not found.");
+        User user = userData.get();
+
+        boolean isBanned = authorityUtil.isBanned(user.getRoles());
+        if (!isBanned) throw new InvalidInputException("username"); // TODO: This must be more specific.
+
+        Optional<Role> unbanData = roleDAO.findByName(EnumAuthorization.USER.getValue());
+        if (unbanData.isEmpty()) throw new FatalErrorException();
+
+        Set<Role> roles = new HashSet<>();
+        Role unban = unbanData.get();
+        roles.add(unban);
+        user.setRoles(roles);
+
+        try {
+            userDAO.save(user);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new FatalErrorException();
+        }
+        return userUtil.wrapUser(user);
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/UserServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/UserServiceImpl.java
@@ -9,12 +9,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 
 @Service(value = "UserServiceImpl")
-@Transactional
 public class UserServiceImpl implements UserDetailsService {
 
     @Autowired
@@ -25,8 +23,6 @@ public class UserServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        // TODO: Investigate why the findByUsername method returns a plain password if both this
-        //  and the AuthenticationServiceImpl class are annotated with @Transactional
         Optional<User> _userData = userDAO.findByUsername(username);
         if (_userData.isPresent()) {
             User _user = _userData.get();

--- a/src/main/java/com/stargazerstudios/existence/symphony/wrapper/UserWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/wrapper/UserWrapper.java
@@ -6,5 +6,8 @@ import lombok.*;
 public class UserWrapper {
     private String username;
     private String password;
+    private String old_password;
+    private String new_password;
+    private String confirm_password;
     private String[] roles;
 }


### PR DESCRIPTION
Starting on this commit, I will no longer specify changes on different classes, unless there is something major that needs to be pointed out.

* Added a bunch of custom exceptions to make the errors more informative. This is not yet finished and will be fully completed, hopefully, on another commit. This is already raised on an issue #5 
* Added capability to ban and unban users and to detect these user status system wide, on the filter level.
* Modified the password changing process to be in line with the standard process used in websites where the correct old password is needed together with two matching instances of the new password.
* Modified the way that the app detects user authority. Previously, the app only detects if the user has a specific rank. Now, the app detects if the user has a specific rank or any other rank with higher authority.
* Added the capability to delete users. This needs a superuser authority or higher.
* Returned the relationship fetching of the User and Role entities to Eager. This change prompt the removal of the Transactional annotation from the controllers that manipulate these two entities, most notably the Authorization controller. This change allows the app to create a new user from scratch and immediately give them authority, something that was not possible (I may be wrong) with the non eager fetching from the previous version.
* Created a bunch of new enums to streamline future coding.
* Added a few integrity checks during app startup for some of the crucial records that the app needs to function correctly.