### PR TITLE
16 default spring validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 			<version>2.6.4</version>
 		</dependency>
+		<!-- Spring Boot Validation -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+			<version>2.6.4</version>
+		</dependency>
 		<!-- Liquibase -->
 		<dependency>
 			<groupId>org.liquibase</groupId>
@@ -87,8 +93,7 @@
 			<artifactId>poi-ooxml</artifactId>
 			<version>5.1.0</version>
 		</dependency>
-
-	</dependencies>
+    </dependencies>
 
 	<build>
 		<resources>

--- a/src/main/java/com/stargazerstudios/existence/ballad/controller/StoryController.java
+++ b/src/main/java/com/stargazerstudios/existence/ballad/controller/StoryController.java
@@ -6,9 +6,11 @@ import com.stargazerstudios.existence.ballad.wrapper.StoryWrapper;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
+import com.stargazerstudios.existence.conductor.validation.groups.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,37 +29,43 @@ public class StoryController {
     }
 
     @GetMapping("/story")
-    public ResponseEntity<StoryDTO> getStory(@RequestBody StoryWrapper story)
+    public ResponseEntity<StoryDTO> getStory(@Validated(GetValidation.class)
+                                                 @RequestBody StoryWrapper story)
             throws UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(storyService.getStory(story), HttpStatus.OK);
     }
 
     @PostMapping("/story")
-    public ResponseEntity<StoryDTO> createStory(@RequestBody StoryWrapper story)
+    public ResponseEntity<StoryDTO> createStory(@Validated(PostValidation.class)
+                                                    @RequestBody StoryWrapper story)
             throws DatabaseErrorException, UnknownInputException {
         return new ResponseEntity<>(storyService.createStory(story), HttpStatus.OK);
     }
 
     @PutMapping("/story")
-    public ResponseEntity<StoryDTO> updateStory(@RequestBody StoryWrapper story)
+    public ResponseEntity<StoryDTO> updateStory(@Validated(PutValidation.class)
+                                                    @RequestBody StoryWrapper story)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(storyService.updateStory(story), HttpStatus.OK);
     }
 
     @PutMapping("/story/add-tags")
-    public ResponseEntity<StoryDTO> addTags(@RequestBody StoryWrapper story)
+    public ResponseEntity<StoryDTO> addTags(@Validated(PutRelationValidation.class)
+                                                @RequestBody StoryWrapper story)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(storyService.addTags(story), HttpStatus.OK);
     }
 
     @PutMapping("/story/remove-tags")
-    public ResponseEntity<StoryDTO> removeTags(@RequestBody StoryWrapper story)
+    public ResponseEntity<StoryDTO> removeTags(@Validated(PutRelationValidation.class)
+                                                   @RequestBody StoryWrapper story)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(storyService.removeTags(story), HttpStatus.OK);
     }
 
     @DeleteMapping("/story")
-    public ResponseEntity<StoryDTO> deleteStory(@RequestBody StoryWrapper story)
+    public ResponseEntity<StoryDTO> deleteStory(@Validated(DeleteValidation.class)
+                                                    @RequestBody StoryWrapper story)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(storyService.deleteStory(story), HttpStatus.OK);
     }

--- a/src/main/java/com/stargazerstudios/existence/ballad/controller/TagController.java
+++ b/src/main/java/com/stargazerstudios/existence/ballad/controller/TagController.java
@@ -6,9 +6,11 @@ import com.stargazerstudios.existence.ballad.wrapper.TagWrapper;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
+import com.stargazerstudios.existence.conductor.validation.groups.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,37 +29,43 @@ public class TagController {
     }
 
     @GetMapping("/tag")
-    public ResponseEntity<TagDTO> getTag(@RequestBody TagWrapper tag)
+    public ResponseEntity<TagDTO> getTag(@Validated(GetValidation.class)
+                                             @RequestBody TagWrapper tag)
             throws UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(tagService.getTag(tag), HttpStatus.OK);
     }
 
     @PostMapping("/tag")
-    public ResponseEntity<TagDTO> createTag(@RequestBody TagWrapper tag)
+    public ResponseEntity<TagDTO> createTag(@Validated(PostValidation.class)
+                                                @RequestBody TagWrapper tag)
             throws DatabaseErrorException, UnknownInputException {
         return new ResponseEntity<>(tagService.createTag(tag), HttpStatus.OK);
     }
 
     @PutMapping("/tag")
-    public ResponseEntity<TagDTO> updateTag(@RequestBody TagWrapper tag)
+    public ResponseEntity<TagDTO> updateTag(@Validated(PutValidation.class)
+                                                @RequestBody TagWrapper tag)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(tagService.updateTag(tag), HttpStatus.OK);
     }
 
     @PutMapping("/tag/add-stories")
-    public ResponseEntity<TagDTO> addStory(@RequestBody TagWrapper tag)
+    public ResponseEntity<TagDTO> addStory(@Validated(PutRelationValidation.class)
+                                               @RequestBody TagWrapper tag)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(tagService.addStories(tag), HttpStatus.OK);
     }
 
     @PutMapping("/tag/remove-stories")
-    public ResponseEntity<TagDTO> removeStory(@RequestBody TagWrapper tag)
+    public ResponseEntity<TagDTO> removeStory(@Validated(PutRelationValidation.class)
+                                                  @RequestBody TagWrapper tag)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(tagService.removeStories(tag), HttpStatus.OK);
     }
 
     @DeleteMapping("/tag")
-    public ResponseEntity<TagDTO> deleteTag(@RequestBody TagWrapper tag)
+    public ResponseEntity<TagDTO> deleteTag(@Validated(DeleteValidation.class)
+                                                @RequestBody TagWrapper tag)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(tagService.deleteTag(tag), HttpStatus.OK);
     }

--- a/src/main/java/com/stargazerstudios/existence/ballad/service/StoryServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/ballad/service/StoryServiceImpl.java
@@ -59,22 +59,21 @@ public class StoryServiceImpl implements StoryService{
     }
 
     @Override
-    public StoryDTO getStory(StoryWrapper story) throws UnknownInputException, EntityErrorException {
-        String storyName = stringUtil.checkInputTrimToUpper(story.getName());
-        if (storyName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
+    public StoryDTO getStory(StoryWrapper story)
+            throws UnknownInputException, EntityErrorException {
+        String storyName = story.getName();
         Optional<Story> storyData = storyDAO.findByName(storyName);
         if (storyData.isPresent()) {
-            StoryDTO storyDTO = storyUtil.wrapStory(storyData.get());
-            return storyDTO;
+            return storyUtil.wrapStory(storyData.get());
         } else {
             throw new EntityNotFoundException("story", "name", storyName);
         }
     }
 
     @Override
-    public StoryDTO createStory(StoryWrapper wStory) throws UnknownInputException, DatabaseErrorException {
-        String name = stringUtil.checkInputTrimToUpper(wStory.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
+    public StoryDTO createStory(StoryWrapper wStory)
+            throws UnknownInputException, DatabaseErrorException {
+        String name = stringUtil.trimToUpper(wStory.getName());
         Story story = new Story();
         story.setName(name);
 
@@ -97,11 +96,8 @@ public class StoryServiceImpl implements StoryService{
     @Override
     public StoryDTO updateStory(StoryWrapper wStory)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException{
-        String name = stringUtil.checkInputTrimToUpper(wStory.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
-
-        String newName = stringUtil.checkInputTrimToUpper(wStory.getNew_name());
-        if (newName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("new_name");
+        String name = stringUtil.trimToUpper(wStory.getName());
+        String newName = stringUtil.trimToUpper(wStory.getNew_name());
 
         Optional<Story> storyData = storyDAO.findByName(name);
         if (storyData.isEmpty()) throw new EntityNotFoundException("story", "name", name);
@@ -128,16 +124,13 @@ public class StoryServiceImpl implements StoryService{
     @Override
     public StoryDTO addTags(StoryWrapper wStory)
             throws UnknownInputException, DatabaseErrorException, EntityErrorException {
-        String name = stringUtil.checkInputTrimToUpper(wStory.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
-
+        String name = stringUtil.trimToUpper(wStory.getName());
         String[] tags = wStory.getTags();
-        if (tags == null || tags.length == 0) throw new InvalidInputException("tags");
         Set<String> tagQuery = new HashSet<>();
 
         for (String tag : tags) {
-            String item = stringUtil.checkInputTrimToUpper(tag);
-            if (item.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
+            String item = stringUtil.trimToUpper(tag);
+            if (item.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("tags");
             tagQuery.add(item);
         }
 
@@ -147,7 +140,6 @@ public class StoryServiceImpl implements StoryService{
         if (!tagQuery.equals(tagResultSet)) {
           tagQuery.removeAll(tagResultSet);
           throw new InvalidInputException("tags");
-          // TODO: This needs to quantify the invalid tags.
         }
 
         Optional<Story> storyData = storyDAO.findByName(name);
@@ -172,11 +164,8 @@ public class StoryServiceImpl implements StoryService{
     @Override
     public StoryDTO removeTags(StoryWrapper wStory)
             throws UnknownInputException, DatabaseErrorException, EntityErrorException {
-        String name = stringUtil.checkInputTrimToUpper(wStory.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
-
+        String name = stringUtil.trimToUpper(wStory.getName());
         String[] tags = wStory.getTags();
-        if (tags == null || tags.length == 0) throw new InvalidInputException("tags");
 
         Optional<Story> storyData = storyDAO.findByName(name);
         if (storyData.isEmpty()) throw new EntityNotFoundException("story", "name", name);
@@ -187,7 +176,7 @@ public class StoryServiceImpl implements StoryService{
 
         Set<String> inputTagNames = new HashSet<>();
         for (String tag: tags) {
-            inputTagNames.add(stringUtil.checkInputTrimToUpper(tag));
+            inputTagNames.add(stringUtil.trimToUpper(tag));
         }
         if (!dbTagNames.containsAll(inputTagNames)) throw new InvalidInputException("tags");
 
@@ -213,22 +202,19 @@ public class StoryServiceImpl implements StoryService{
     @Override
     public StoryDTO deleteStory(StoryWrapper wStory)
             throws UnknownInputException, DatabaseErrorException, EntityErrorException{
-        String storyName = stringUtil.checkInputTrimToUpper(wStory.getName());
-        if (storyName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
+        String storyName = stringUtil.trimToUpper(wStory.getName());
         Optional<Story> storyData = storyDAO.findByName(storyName);
-        if (storyData.isPresent()) {
-            Story story = storyData.get();
+        if (storyData.isEmpty()) throw new EntityNotFoundException("story", "name", storyName);
+        
+        Story story = storyData.get();
 
-            try {
-                storyDAO.delete(story);
-            } catch (Exception e) {
-                e.printStackTrace();
-                throw new EntityDeletionErrorException("story");
-            }
-
-            return storyUtil.wrapStory(story);
-        } else {
-            throw new EntityNotFoundException("story", "name", storyName);
+        try {
+            storyDAO.delete(story);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new EntityDeletionErrorException("story");
         }
+        
+        return storyUtil.wrapStory(story);
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/ballad/service/TagServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/ballad/service/TagServiceImpl.java
@@ -59,13 +59,12 @@ public class TagServiceImpl implements TagService{
     }
 
     @Override
-    public TagDTO getTag(TagWrapper tag) throws UnknownInputException, EntityErrorException {
+    public TagDTO getTag(TagWrapper tag)
+            throws UnknownInputException, EntityErrorException {
         String tagName = stringUtil.checkInputTrimToUpper(tag.getName());
-        if (tagName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
         Optional<Tag> tagData = tagDAO.findByName(tagName);
         if (tagData.isPresent()) {
-            TagDTO tagDTO = tagUtil.wrapTag(tagData.get());
-            return tagDTO;
+            return tagUtil.wrapTag(tagData.get());
         } else {
             throw new EntityNotFoundException("tag", "name", tagName);
         }
@@ -74,7 +73,6 @@ public class TagServiceImpl implements TagService{
     @Override
     public TagDTO createTag(TagWrapper wTag) throws DatabaseErrorException, UnknownInputException {
         String name = stringUtil.checkInputTrimToUpper(wTag.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
 
         Tag tag = new Tag();
         tag.setName(name);
@@ -99,10 +97,8 @@ public class TagServiceImpl implements TagService{
     public TagDTO updateTag(TagWrapper wTag)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException {
         String name = stringUtil.checkInputTrimToUpper(wTag.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
 
         String newName = stringUtil.checkInputTrimToUpper(wTag.getNew_name());
-        if (newName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("new_name");
 
         Optional<Tag> tagData = tagDAO.findByName(name);
         if (tagData.isEmpty()) throw new EntityNotFoundException("tag", "name", name);
@@ -130,15 +126,13 @@ public class TagServiceImpl implements TagService{
     public TagDTO addStories(TagWrapper wTag)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException{
         String name = stringUtil.checkInputTrimToUpper(wTag.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
 
         String[] stories = wTag.getStories();
-        if (stories == null || stories.length == 0) throw new InvalidInputException("stories");
         Set<String> storyQuery = new HashSet<>();
 
         for (String story : stories) {
             String item = stringUtil.checkInputTrimToUpper(story);
-            if (item.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
+            if (item.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("stories");
             storyQuery.add(item);
         }
 
@@ -148,7 +142,6 @@ public class TagServiceImpl implements TagService{
         if (!storyQuery.equals(storyResultSet)) {
             storyQuery.removeAll(storyResultSet);
             throw new InvalidInputException("stories");
-            // TODO: This needs to quantify the invalid stories.
         }
 
         Optional<Tag> tagData = tagDAO.findByName(name);
@@ -174,10 +167,8 @@ public class TagServiceImpl implements TagService{
     public TagDTO removeStories(TagWrapper wTag)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException {
         String name = stringUtil.checkInputTrimToUpper(wTag.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
 
         String[] stories = wTag.getStories();
-        if (stories == null || stories.length == 0) throw new InvalidInputException("stories");
 
         Optional<Tag> tagData = tagDAO.findByName(name);
         if (tagData.isEmpty()) throw new EntityNotFoundException("tag", "name", name);
@@ -215,7 +206,6 @@ public class TagServiceImpl implements TagService{
     public TagDTO deleteTag(TagWrapper wTag)
             throws UnknownInputException, DatabaseErrorException, EntityErrorException{
         String tagName = stringUtil.checkInputTrimToUpper(wTag.getName());
-        if (tagName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
 
         Optional<Tag> tagData = tagDAO.findByName(tagName);
         if (tagData.isPresent()) {

--- a/src/main/java/com/stargazerstudios/existence/ballad/wrapper/StoryWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/ballad/wrapper/StoryWrapper.java
@@ -1,11 +1,22 @@
 package com.stargazerstudios.existence.ballad.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.*;
 import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 @Getter @Setter @NoArgsConstructor
 public class StoryWrapper {
     private long id;
+    @NotBlank(groups = PostValidation.class)
+    @NotBlank(groups = GetValidation.class)
+    @NotBlank(groups = PutValidation.class)
+    @NotBlank(groups = PutRelationValidation.class)
+    @NotBlank(groups = DeleteValidation.class)
     private String name;
+    @NotBlank(groups = PutValidation.class)
     private String new_name;
+    @NotEmpty(groups = PutRelationValidation.class)
     private String[] tags;
 }

--- a/src/main/java/com/stargazerstudios/existence/ballad/wrapper/StoryWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/ballad/wrapper/StoryWrapper.java
@@ -9,11 +9,10 @@ import javax.validation.constraints.NotEmpty;
 @Getter @Setter @NoArgsConstructor
 public class StoryWrapper {
     private long id;
-    @NotBlank(groups = PostValidation.class)
-    @NotBlank(groups = GetValidation.class)
-    @NotBlank(groups = PutValidation.class)
-    @NotBlank(groups = PutRelationValidation.class)
-    @NotBlank(groups = DeleteValidation.class)
+    @NotBlank(groups = {
+            PostValidation.class, GetValidation.class, PutValidation.class,
+            PutRelationValidation.class, DeleteValidation.class
+    })
     private String name;
     @NotBlank(groups = PutValidation.class)
     private String new_name;

--- a/src/main/java/com/stargazerstudios/existence/ballad/wrapper/TagWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/ballad/wrapper/TagWrapper.java
@@ -1,11 +1,22 @@
 package com.stargazerstudios.existence.ballad.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.*;
 import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 @Getter @Setter @NoArgsConstructor
 public class TagWrapper {
     private long id;
+    @NotBlank(groups = PostValidation.class)
+    @NotBlank(groups = GetValidation.class)
+    @NotBlank(groups = PutValidation.class)
+    @NotBlank(groups = PutRelationValidation.class)
+    @NotBlank(groups = DeleteValidation.class)
     private String name;
+    @NotBlank(groups = PutValidation.class)
     private String new_name;
+    @NotEmpty(groups = PutRelationValidation.class)
     private String[] stories;
 }

--- a/src/main/java/com/stargazerstudios/existence/ballad/wrapper/TagWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/ballad/wrapper/TagWrapper.java
@@ -9,11 +9,10 @@ import javax.validation.constraints.NotEmpty;
 @Getter @Setter @NoArgsConstructor
 public class TagWrapper {
     private long id;
-    @NotBlank(groups = PostValidation.class)
-    @NotBlank(groups = GetValidation.class)
-    @NotBlank(groups = PutValidation.class)
-    @NotBlank(groups = PutRelationValidation.class)
-    @NotBlank(groups = DeleteValidation.class)
+    @NotBlank(groups = {
+            PostValidation.class, GetValidation.class, PutValidation.class,
+            PutRelationValidation.class, DeleteValidation.class
+    })
     private String name;
     @NotBlank(groups = PutValidation.class)
     private String new_name;

--- a/src/main/java/com/stargazerstudios/existence/conductor/erratum/RestExceptionHandler.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/erratum/RestExceptionHandler.java
@@ -1,14 +1,21 @@
 package com.stargazerstudios.existence.conductor.erratum;
 
 import com.stargazerstudios.existence.conductor.erratum.authorization.UserNotLoggedInException;
+import com.stargazerstudios.existence.conductor.erratum.input.InvalidInputException;
 import com.stargazerstudios.existence.conductor.erratum.root.*;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Objects;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
@@ -67,6 +74,20 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
             AuthenticationException ex) {
         UserNotLoggedInException _ex = new UserNotLoggedInException();
         ErrorResponse errorResponse = new ErrorResponse(_ex.getHttpStatus());
+        errorResponse.setMessage(_ex.getMessage());
+        return buildResponseEntity(errorResponse);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        return handleMethodArgumentNotValidError(ex);
+    }
+
+    private ResponseEntity<Object> handleMethodArgumentNotValidError(MethodArgumentNotValidException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST);
+        String errorMessage = Objects.requireNonNull(ex.getFieldError(), "Invalid input.").getField();
+        InvalidInputException _ex = new InvalidInputException(errorMessage);
         errorResponse.setMessage(_ex.getMessage());
         return buildResponseEntity(errorResponse);
     }

--- a/src/main/java/com/stargazerstudios/existence/conductor/utils/StringUtil.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/utils/StringUtil.java
@@ -6,6 +6,18 @@ import org.springframework.stereotype.Service;
 @Service
 public class StringUtil {
 
+    /**
+     * Trims and transforms a string to uppercase.
+     * Be careful because it does
+     * not have any null or empty checks.
+     * @param in The string to transform.
+     * @return String object that has been trimmed and transformed to uppercase.
+     * @since v0.2-beta
+     */
+    public String trimToUpper(String in) {
+        return in.trim().toUpperCase();
+    }
+
     public String checkInput(String in) {
         if (in != null && !in.isBlank()) {
             return in;

--- a/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/AuthValidation.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/AuthValidation.java
@@ -1,0 +1,4 @@
+package com.stargazerstudios.existence.conductor.validation.groups;
+
+public interface AuthValidation {
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/DeleteValidation.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/DeleteValidation.java
@@ -1,0 +1,4 @@
+package com.stargazerstudios.existence.conductor.validation.groups;
+
+public interface DeleteValidation {
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/GetValidation.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/GetValidation.java
@@ -1,0 +1,4 @@
+package com.stargazerstudios.existence.conductor.validation.groups;
+
+public interface GetValidation {
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/PostRelationValidation.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/PostRelationValidation.java
@@ -1,0 +1,4 @@
+package com.stargazerstudios.existence.conductor.validation.groups;
+
+public interface PostRelationValidation {
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/PostValidation.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/PostValidation.java
@@ -1,0 +1,4 @@
+package com.stargazerstudios.existence.conductor.validation.groups;
+
+public interface PostValidation {
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/PutRelationValidation.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/PutRelationValidation.java
@@ -1,0 +1,4 @@
+package com.stargazerstudios.existence.conductor.validation.groups;
+
+public interface PutRelationValidation {
+}

--- a/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/PutValidation.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/validation/groups/PutValidation.java
@@ -1,0 +1,4 @@
+package com.stargazerstudios.existence.conductor.validation.groups;
+
+public interface PutValidation {
+}

--- a/src/main/java/com/stargazerstudios/existence/sonata/controller/EventController.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/controller/EventController.java
@@ -4,6 +4,8 @@ import com.stargazerstudios.existence.conductor.erratum.root.AuthorizationErrorE
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
+import com.stargazerstudios.existence.conductor.validation.groups.PutValidation;
 import com.stargazerstudios.existence.sonata.dto.EventDTO;
 import com.stargazerstudios.existence.sonata.service.EventServiceImpl;
 import com.stargazerstudios.existence.sonata.utils.EventExporterUtil;
@@ -11,6 +13,7 @@ import com.stargazerstudios.existence.sonata.wrapper.EventWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -40,13 +43,15 @@ public class EventController {
     }
 
     @PostMapping("/event")
-    public ResponseEntity<EventDTO> createEvent(@RequestBody EventWrapper event)
+    public ResponseEntity<EventDTO> createEvent(@Validated(PostValidation.class)
+                                                    @RequestBody EventWrapper event)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException {
         return new ResponseEntity<>(eventService.createEvent(event), HttpStatus.OK);
     }
 
     @PutMapping("/event")
-    public ResponseEntity<EventDTO> updateEvent(@RequestBody EventWrapper event)
+    public ResponseEntity<EventDTO> updateEvent(@Validated(PutValidation.class)
+                                                    @RequestBody EventWrapper event)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException, AuthorizationErrorException {
         return new ResponseEntity<>(eventService.updateEvent(event), HttpStatus.OK);
     }

--- a/src/main/java/com/stargazerstudios/existence/sonata/controller/MachineController.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/controller/MachineController.java
@@ -3,12 +3,15 @@ package com.stargazerstudios.existence.sonata.controller;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
+import com.stargazerstudios.existence.conductor.validation.groups.PutValidation;
 import com.stargazerstudios.existence.sonata.dto.MachineDTO;
 import com.stargazerstudios.existence.sonata.service.MachineServiceImpl;
 import com.stargazerstudios.existence.sonata.wrapper.MachineWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,13 +30,15 @@ public class MachineController {
     }
 
     @PostMapping("/machine")
-    public ResponseEntity<MachineDTO> createMachine(@RequestBody MachineWrapper wMachine)
+    public ResponseEntity<MachineDTO> createMachine(@Validated(PostValidation.class)
+                                                        @RequestBody MachineWrapper wMachine)
             throws DatabaseErrorException, UnknownInputException {
         return new ResponseEntity<>(machineService.createMachine(wMachine), HttpStatus.OK);
     }
 
     @PutMapping("/machine")
-    public ResponseEntity<MachineDTO> updateMachine(@RequestBody MachineWrapper wMachine)
+    public ResponseEntity<MachineDTO> updateMachine(@Validated(PutValidation.class)
+                                                        @RequestBody MachineWrapper wMachine)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(machineService.updateMachine(wMachine), HttpStatus.OK);
     }

--- a/src/main/java/com/stargazerstudios/existence/sonata/controller/SystemController.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/controller/SystemController.java
@@ -3,12 +3,14 @@ package com.stargazerstudios.existence.sonata.controller;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
 import com.stargazerstudios.existence.sonata.dto.SystemDTO;
 import com.stargazerstudios.existence.sonata.service.SystemServiceImpl;
 import com.stargazerstudios.existence.sonata.wrapper.SystemWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,7 +29,8 @@ public class SystemController {
     }
 
     @PostMapping("/system")
-    public ResponseEntity<SystemDTO> createSystem(@RequestBody SystemWrapper wSystem)
+    public ResponseEntity<SystemDTO> createSystem(@Validated(PostValidation.class)
+                                                      @RequestBody SystemWrapper wSystem)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException {
         return new ResponseEntity<>(systemService.createSystem(wSystem), HttpStatus.OK);
     }

--- a/src/main/java/com/stargazerstudios/existence/sonata/controller/ZoneController.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/controller/ZoneController.java
@@ -3,12 +3,14 @@ package com.stargazerstudios.existence.sonata.controller;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
 import com.stargazerstudios.existence.sonata.dto.ZoneDTO;
 import com.stargazerstudios.existence.sonata.service.ZoneServiceImpl;
 import com.stargazerstudios.existence.sonata.wrapper.ZoneWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,7 +29,8 @@ public class ZoneController {
     }
 
     @PostMapping("/zone")
-    public ResponseEntity<ZoneDTO> createZone(@RequestBody ZoneWrapper wZone)
+    public ResponseEntity<ZoneDTO> createZone(@Validated(PostValidation.class)
+                                                  @RequestBody ZoneWrapper wZone)
             throws DatabaseErrorException, UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(zoneService.createZone(wZone), HttpStatus.OK);
     }

--- a/src/main/java/com/stargazerstudios/existence/sonata/service/EventServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/service/EventServiceImpl.java
@@ -108,23 +108,11 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventDTO createEvent(EventWrapper wEvent)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException {
-        // Check required fields
-        String startDateIn = stringUtil.checkInputTrimToUpper(wEvent.getStart_date());
-        if (startDateIn.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("start_date");
-        String endDateIn = stringUtil.checkInputTrimToUpper(wEvent.getEnd_date());
-        if (endDateIn.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("end_date");
-        String globalPrefix = stringUtil.checkInputTrimToUpper(wEvent.getGlobal_prefix());
-        if (globalPrefix.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("global_prefix");
-        String machine = stringUtil.checkInputTrimToUpper(wEvent.getMachine());
-        if (machine.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("machine");
+        String startDateIn = stringUtil.trimToUpper(wEvent.getStart_date());
+        String endDateIn = stringUtil.trimToUpper(wEvent.getEnd_date());
+        String globalPrefix = stringUtil.trimToUpper(wEvent.getGlobal_prefix());
+        String machine = stringUtil.trimToUpper(wEvent.getMachine());
 
-        // Check arrays
-        String[] eventTypesArr = wEvent.getEvent_types();
-        if (eventTypesArr == null || eventTypesArr.length == 0) throw new InvalidInputException("event_types");
-        String[] zonesArr = wEvent.getZones();
-        if (zonesArr == null || zonesArr.length == 0) throw new InvalidInputException("zones");
-
-        // Validate dates
         LocalDate startDate;
         try {
             startDate = LocalDate.parse(startDateIn);
@@ -141,6 +129,7 @@ public class EventServiceImpl implements EventService {
 
         if (endDate.isBefore(startDate)) throw new InvalidInputException("end_date");
 
+        String[] eventTypesArr = wEvent.getEvent_types();
         Set<String> eventTypeQuery = new HashSet<>();
         for (String item: eventTypesArr) {
             String out = stringUtil.checkInputTrimToUpper(item);
@@ -149,6 +138,7 @@ public class EventServiceImpl implements EventService {
             eventTypeQuery.add(out);
         }
 
+        String[] zonesArr = wEvent.getZones();
         Set<String> zoneQuery = new HashSet<>();
         for (String item: zonesArr) {
             String out = stringUtil.checkInputTrimToUpper(item);
@@ -217,7 +207,6 @@ public class EventServiceImpl implements EventService {
     public EventDTO updateEvent(EventWrapper wEvent)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException, AuthorizationErrorException {
         long id = wEvent.getId();
-        if (id <= 0) throw new InvalidInputException("id");
 
         String globalPrefixIn = null;
         String machineIn = null;
@@ -295,7 +284,8 @@ public class EventServiceImpl implements EventService {
         System system = null;
         if (globalPrefixIn != null && machineIn != null) {
             Optional<System> systemData = systemDAO.findSystemOnMachine(globalPrefixIn, machineIn);
-            if (systemData.isEmpty()) throw new EntityNotFoundException("system", "global_prefix", globalPrefixIn, "machine", "name", machineIn);
+            if (systemData.isEmpty())
+                throw new EntityNotFoundException("system", "global_prefix", globalPrefixIn, "machine", "name", machineIn);
             system = systemData.get();
             event.setSystem(system);
         }

--- a/src/main/java/com/stargazerstudios/existence/sonata/service/MachineServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/service/MachineServiceImpl.java
@@ -1,10 +1,8 @@
 package com.stargazerstudios.existence.sonata.service;
 
-import com.stargazerstudios.existence.conductor.constants.EnumUtilOutput;
 import com.stargazerstudios.existence.conductor.erratum.database.EntitySaveErrorException;
 import com.stargazerstudios.existence.conductor.erratum.database.DuplicateEntityException;
 import com.stargazerstudios.existence.conductor.erratum.entity.EntityNotFoundException;
-import com.stargazerstudios.existence.conductor.erratum.input.InvalidInputException;
 import com.stargazerstudios.existence.conductor.erratum.input.UnexpectedInputException;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
@@ -69,8 +67,7 @@ public class MachineServiceImpl implements MachineService {
     @Override
     public MachineDTO createMachine(MachineWrapper wMachine)
             throws UnknownInputException, DatabaseErrorException {
-        String name = stringUtil.checkInputTrimToUpper(wMachine.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
+        String name = stringUtil.trimToUpper(wMachine.getName());
 
         Machine machine = new Machine();
         machine.setName(name);
@@ -79,13 +76,13 @@ public class MachineServiceImpl implements MachineService {
             machineDAO.save(machine);
         } catch (DataIntegrityViolationException e) {
             e.printStackTrace();
-            throw new DuplicateEntityException("machine", "name", name);
-        } catch (Exception e) {
-            e.printStackTrace();
             ConstraintViolationException ex = (ConstraintViolationException) e.getCause();
             String constraint = ex.getConstraintName();
-            if (constraint.equals(ConsSonataConstraint.UNIQUE_SYSTEM_PER_MACHINE))
+            if (constraint.equals(ConsSonataConstraint.UNIQUE_MACHINE_NAME))
                 throw new DuplicateEntityException("machine", "name", name);
+            throw new EntitySaveErrorException("machine");
+        } catch (Exception e) {
+            e.printStackTrace();
             throw new EntitySaveErrorException("machine");
         }
 
@@ -95,12 +92,8 @@ public class MachineServiceImpl implements MachineService {
     @Override
     public MachineDTO updateMachine(MachineWrapper wMachine)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException {
-        String name = stringUtil.checkInputTrimToUpper(wMachine.getName());
-        if (name.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("name");
-
-        String newName = stringUtil.checkInputTrimToUpper(wMachine.getNew_name());
-        if (newName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("new_name");
-
+        String name = stringUtil.trimToUpper(wMachine.getName());
+        String newName = stringUtil.trimToUpper(wMachine.getNew_name());
         if (name.equals(newName)) throw new UnexpectedInputException("new_name is same as the current name");
 
         Optional<Machine> machineData = machineDAO.findByName(name);
@@ -115,7 +108,7 @@ public class MachineServiceImpl implements MachineService {
             e.printStackTrace();
             ConstraintViolationException ex = (ConstraintViolationException) e.getCause();
             String constraint = ex.getConstraintName();
-            if (constraint.equals(ConsSonataConstraint.UNIQUE_SYSTEM_PER_MACHINE))
+            if (constraint.equals(ConsSonataConstraint.UNIQUE_MACHINE_NAME))
                 throw new DuplicateEntityException("machine", "name", newName);
             throw new EntitySaveErrorException("machine");
         } catch (Exception e) {

--- a/src/main/java/com/stargazerstudios/existence/sonata/service/SystemServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/service/SystemServiceImpl.java
@@ -1,10 +1,8 @@
 package com.stargazerstudios.existence.sonata.service;
 
-import com.stargazerstudios.existence.conductor.constants.EnumUtilOutput;
 import com.stargazerstudios.existence.conductor.erratum.database.EntitySaveErrorException;
 import com.stargazerstudios.existence.conductor.erratum.database.DuplicateEntityException;
 import com.stargazerstudios.existence.conductor.erratum.entity.EntityNotFoundException;
-import com.stargazerstudios.existence.conductor.erratum.input.InvalidInputException;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
@@ -60,11 +58,8 @@ public class SystemServiceImpl implements SystemService {
     @Override
     public SystemDTO createSystem(SystemWrapper wSystem)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException {
-        String globalPrefix = stringUtil.checkInputTrimToUpper(wSystem.getGlobal_prefix());
-        if (globalPrefix.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("global_prefix");
-
-        String machineName = stringUtil.checkInputTrimToUpper(wSystem.getMachine());
-        if (machineName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("machine");
+        String globalPrefix = stringUtil.trimToUpper(wSystem.getGlobal_prefix());
+        String machineName = stringUtil.trimToUpper(wSystem.getMachine());
 
         Optional<Machine> machineData = machineDAO.findByName(machineName);
         if (machineData.isEmpty()) throw new EntityNotFoundException("machine", "name", machineName);

--- a/src/main/java/com/stargazerstudios/existence/sonata/service/ZoneServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/service/ZoneServiceImpl.java
@@ -1,10 +1,8 @@
 package com.stargazerstudios.existence.sonata.service;
 
-import com.stargazerstudios.existence.conductor.constants.EnumUtilOutput;
 import com.stargazerstudios.existence.conductor.erratum.database.EntitySaveErrorException;
 import com.stargazerstudios.existence.conductor.erratum.database.DuplicateEntityException;
 import com.stargazerstudios.existence.conductor.erratum.entity.EntityNotFoundException;
-import com.stargazerstudios.existence.conductor.erratum.input.InvalidInputException;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
@@ -64,24 +62,17 @@ public class ZoneServiceImpl implements ZoneService{
     @Override
     public ZoneDTO createZone(ZoneWrapper wZone)
             throws UnknownInputException, EntityErrorException, DatabaseErrorException {
-        String zonalPrefix = stringUtil.checkInputTrimToUpper(wZone.getZonal_prefix());
-        if (zonalPrefix.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("zonal_prefix");
-
-        String zoneName = stringUtil.checkInputTrimToUpper(wZone.getZone_name());
-        if (zoneName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("zone_name");
-
-        String systemName = stringUtil.checkInputTrimToUpper(wZone.getSystem());
-        if (systemName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("system");
-
-        String machineName = stringUtil.checkInputTrimToUpper(wZone.getMachine());
-        if (machineName.equals(EnumUtilOutput.EMPTY.getValue())) throw new InvalidInputException("machine");
+        String zonalPrefix = stringUtil.trimToUpper(wZone.getZonal_prefix());
+        String zoneName = stringUtil.trimToUpper(wZone.getZone_name());
+        String systemName = stringUtil.trimToUpper(wZone.getSystem());
+        String machineName = stringUtil.trimToUpper(wZone.getMachine());
 
         Optional<System> systemData = systemDAO.findSystemOnMachine(systemName, machineName);
         if (systemData.isEmpty()) throw new EntityNotFoundException("system", "global_prefix", systemName);
 
         Zone zone = new Zone();
-        zone.setZoneName(wZone.getZone_name());
-        zone.setZonalPrefix(wZone.getZonal_prefix());
+        zone.setZoneName(zoneName);
+        zone.setZonalPrefix(zonalPrefix);
         zone.setSystem(systemData.get());
 
         try {

--- a/src/main/java/com/stargazerstudios/existence/sonata/wrapper/EventWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/wrapper/EventWrapper.java
@@ -1,19 +1,44 @@
 package com.stargazerstudios.existence.sonata.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
+import com.stargazerstudios.existence.conductor.validation.groups.PutValidation;
 import lombok.*;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 @Getter @Setter @NoArgsConstructor
 public class EventWrapper {
+
+    @Min(value = 1, groups = PutValidation.class)
     private long id;
+
+    @NotBlank(groups = PostValidation.class)
     private String global_prefix;
+
+    @NotBlank(groups = PostValidation.class)
     private String machine;
+
+    @NotEmpty(groups = PostValidation.class)
     private String[] zones;
+
+    @NotEmpty(groups = PostValidation.class)
     private String[] event_types;
+
+    @NotBlank(groups = PostValidation.class)
     private String start_date;
+
+    @NotBlank(groups = PostValidation.class)
     private String end_date;
+
     private String jira_case;
+
     private String features_on;
+
     private String features_off;
+
     private String compiled_sources;
+
     private String api_used;
 }

--- a/src/main/java/com/stargazerstudios/existence/sonata/wrapper/MachineWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/wrapper/MachineWrapper.java
@@ -1,10 +1,18 @@
 package com.stargazerstudios.existence.sonata.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
+import com.stargazerstudios.existence.conductor.validation.groups.PutValidation;
 import lombok.*;
+
+import javax.validation.constraints.NotBlank;
 
 @Getter @Setter @NoArgsConstructor
 public class MachineWrapper {
     private long id;
+    @NotBlank(groups = {
+            PostValidation.class, PutValidation.class
+    })
     private String name;
+    @NotBlank(groups = PutValidation.class)
     private String new_name;
 }

--- a/src/main/java/com/stargazerstudios/existence/sonata/wrapper/SystemWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/wrapper/SystemWrapper.java
@@ -1,14 +1,23 @@
 package com.stargazerstudios.existence.sonata.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
 import lombok.*;
+
+import javax.validation.constraints.NotBlank;
 
 @Getter @Setter @NoArgsConstructor
 public class SystemWrapper {
     private long id;
+    @NotBlank(groups = {
+            PostValidation.class
+    })
     private String global_prefix;
     private String description;
     private String url;
     private String owners;
+    @NotBlank(groups = {
+            PostValidation.class
+    })
     private String machine;
     private String new_machine;
 }

--- a/src/main/java/com/stargazerstudios/existence/sonata/wrapper/ZoneWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/sonata/wrapper/ZoneWrapper.java
@@ -1,14 +1,27 @@
 package com.stargazerstudios.existence.sonata.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
 import lombok.*;
+
+import javax.validation.constraints.NotBlank;
 
 @Getter @Setter @NoArgsConstructor
 public class ZoneWrapper {
     private long id;
+
+    @NotBlank(groups = PostValidation.class)
     private String zonal_prefix;
+
+    @NotBlank(groups = PostValidation.class)
     private String zone_name;
+
     private String new_zonal_prefix;
+
+    @NotBlank(groups = PostValidation.class)
     private String system;
+
     private String new_system;
+
+    @NotBlank(groups = PostValidation.class)
     private String machine;
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/constants/ConsSymphonyConstraint.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/constants/ConsSymphonyConstraint.java
@@ -1,0 +1,5 @@
+package com.stargazerstudios.existence.symphony.constants;
+
+public class ConsSymphonyConstraint {
+    public static final String UNIQUE_USERNAME = "ct_unique_username";
+}

--- a/src/main/java/com/stargazerstudios/existence/symphony/controller/AuthenticationController.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/controller/AuthenticationController.java
@@ -2,12 +2,14 @@ package com.stargazerstudios.existence.symphony.controller;
 
 import com.stargazerstudios.existence.conductor.erratum.root.*;
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
+import com.stargazerstudios.existence.conductor.validation.groups.PostValidation;
 import com.stargazerstudios.existence.symphony.dto.UserDTO;
 import com.stargazerstudios.existence.symphony.service.AuthenticationServiceImpl;
 import com.stargazerstudios.existence.symphony.wrapper.UserWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -22,10 +24,10 @@ public class AuthenticationController {
     private AuthenticationServiceImpl authenticationService;
 
     @PostMapping("/login")
-    public ResponseEntity<UserDTO> login(@RequestBody UserWrapper user)
-            throws AuthorizationErrorException, SystemErrorException,
-                DatabaseErrorException, UnknownInputException,
-                ThirdPartyErrorException, EntityErrorException {
+    public ResponseEntity<UserDTO> login(@Validated(PostValidation.class)
+                                             @RequestBody UserWrapper user)
+            throws AuthorizationErrorException, SystemErrorException, DatabaseErrorException,
+                UnknownInputException, ThirdPartyErrorException, EntityErrorException {
         return new ResponseEntity<>(authenticationService.login(user), HttpStatus.OK);
     }
 

--- a/src/main/java/com/stargazerstudios/existence/symphony/controller/RoleController.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/controller/RoleController.java
@@ -1,12 +1,14 @@
 package com.stargazerstudios.existence.symphony.controller;
 
 import com.stargazerstudios.existence.conductor.erratum.entity.EntityNotFoundException;
+import com.stargazerstudios.existence.conductor.validation.groups.GetValidation;
 import com.stargazerstudios.existence.symphony.dto.RoleDTO;
 import com.stargazerstudios.existence.symphony.service.RoleServiceImpl;
 import com.stargazerstudios.existence.symphony.wrapper.RoleWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,7 +27,9 @@ public class RoleController {
     }
 
     @GetMapping("/role")
-    public ResponseEntity<RoleDTO> getRole(@RequestBody RoleWrapper role) throws EntityNotFoundException {
+    public ResponseEntity<RoleDTO> getRole(@Validated(GetValidation.class)
+                                               @RequestBody RoleWrapper role)
+            throws EntityNotFoundException {
         return new ResponseEntity<>(roleService.getRole(role), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/controller/UserController.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/controller/UserController.java
@@ -4,7 +4,6 @@ import com.stargazerstudios.existence.conductor.erratum.root.AuthorizationErrorE
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
-import com.stargazerstudios.existence.conductor.erratum.universal.*;
 import com.stargazerstudios.existence.symphony.dto.UserDTO;
 import com.stargazerstudios.existence.symphony.service.UserAccessService;
 import com.stargazerstudios.existence.symphony.wrapper.UserWrapper;

--- a/src/main/java/com/stargazerstudios/existence/symphony/controller/UserController.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/controller/UserController.java
@@ -4,12 +4,14 @@ import com.stargazerstudios.existence.conductor.erratum.root.AuthorizationErrorE
 import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.UnknownInputException;
+import com.stargazerstudios.existence.conductor.validation.groups.*;
 import com.stargazerstudios.existence.symphony.dto.UserDTO;
 import com.stargazerstudios.existence.symphony.service.UserAccessService;
 import com.stargazerstudios.existence.symphony.wrapper.UserWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,55 +30,63 @@ public class UserController {
     }
 
     @GetMapping("/user")
-    public ResponseEntity<UserDTO> getUser(@RequestBody UserWrapper user)
+    public ResponseEntity<UserDTO> getUser(@Validated(GetValidation.class)
+                                               @RequestBody UserWrapper user)
             throws UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(userAccessService.getUser(user), HttpStatus.OK);
     }
 
     @PostMapping("/user")
-    public ResponseEntity<UserDTO> createUser(@RequestBody UserWrapper user)
+    public ResponseEntity<UserDTO> createUser(@Validated(PostValidation.class)
+                                                  @RequestBody UserWrapper user)
             throws AuthorizationErrorException, DatabaseErrorException,
                 UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(userAccessService.createUser(user), HttpStatus.OK);
     }
 
     @PutMapping("/user/change-password")
-    public ResponseEntity<UserDTO> updateUserPassword(@RequestBody UserWrapper user)
+    public ResponseEntity<UserDTO> updateUserPassword(@Validated(PutValidation.class)
+                                                          @RequestBody UserWrapper user)
             throws AuthorizationErrorException, DatabaseErrorException,
                 UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(userAccessService.updateUserPassword(user), HttpStatus.OK);
     }
 
     @PutMapping("/user/add-roles")
-    public ResponseEntity<UserDTO> addRoles(@RequestBody UserWrapper user)
+    public ResponseEntity<UserDTO> addRoles(@Validated(PutRelationValidation.class)
+                                                @RequestBody UserWrapper user)
             throws AuthorizationErrorException, DatabaseErrorException,
                 UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(userAccessService.addRoles(user), HttpStatus.OK);
     }
 
     @PutMapping("/user/remove-roles")
-    public ResponseEntity<UserDTO> removeRoles(@RequestBody UserWrapper user)
+    public ResponseEntity<UserDTO> removeRoles(@Validated(PutRelationValidation.class)
+                                                   @RequestBody UserWrapper user)
             throws AuthorizationErrorException, DatabaseErrorException,
                 UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(userAccessService.removeRoles(user), HttpStatus.OK);
     }
 
     @PutMapping("/user/ban-user")
-    public ResponseEntity<UserDTO> banUser(@RequestBody UserWrapper user)
+    public ResponseEntity<UserDTO> banUser(@Validated(AuthValidation.class)
+                                               @RequestBody UserWrapper user)
             throws AuthorizationErrorException, DatabaseErrorException,
                 UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(userAccessService.banUser(user), HttpStatus.OK);
     }
 
     @PutMapping("/user/unban-user")
-    public ResponseEntity<UserDTO> unbanUser(@RequestBody UserWrapper user)
+    public ResponseEntity<UserDTO> unbanUser(@Validated(AuthValidation.class)
+                                                 @RequestBody UserWrapper user)
             throws AuthorizationErrorException, DatabaseErrorException,
                 UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(userAccessService.unbanUser(user), HttpStatus.OK);
     }
 
     @DeleteMapping("/user")
-    public ResponseEntity<UserDTO> deleteUser(@RequestBody UserWrapper user)
+    public ResponseEntity<UserDTO> deleteUser(@Validated(DeleteValidation.class)
+                                                  @RequestBody UserWrapper user)
             throws AuthorizationErrorException, DatabaseErrorException,
                 UnknownInputException, EntityErrorException {
         return new ResponseEntity<>(userAccessService.deleteUser(user), HttpStatus.OK);

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/AuthenticationServiceImpl.java
@@ -35,6 +35,7 @@ import org.springframework.security.web.authentication.rememberme.AbstractRememb
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.UnsupportedMediaTypeException;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 import javax.servlet.http.HttpServletRequest;
@@ -89,10 +90,12 @@ public class AuthenticationServiceImpl implements AuthenticationService{
             throws UnknownInputException, AuthorizationErrorException,
                 SystemErrorException, ThirdPartyErrorException,
                 DatabaseErrorException, EntityErrorException {
-        String username = stringUtil.checkInput(wUser.getUsername());
-        String password = stringUtil.checkInput(wUser.getPassword());
-        if (username.equals(EnumUtilOutput.EMPTY.getValue()) || password.equals(EnumUtilOutput.EMPTY.getValue()))
-            throw new InvalidInputException("username or password");
+//        String username = stringUtil.checkInput(wUser.getUsername());
+//        String password = stringUtil.checkInput(wUser.getPassword());
+//        if (username.equals(EnumUtilOutput.EMPTY.getValue()) || password.equals(EnumUtilOutput.EMPTY.getValue()))
+//            throw new InvalidInputException("username or password");
+        String username = wUser.getUsername();
+        String password = wUser.getPassword();
         Optional<User> userData = userDAO.findByUsername(username);
         // If user is found, check if raw password matches with hash
         if (userData.isPresent()) {
@@ -210,7 +213,7 @@ public class AuthenticationServiceImpl implements AuthenticationService{
         try {
             User userLDAP = userMono.block(Duration.ofMillis(20000));
             return userLDAP.getUsername() != null && !userLDAP.getUsername().isEmpty();
-        } catch (UnsupportedMediaTypeException e) {
+        } catch (WebClientResponseException e) {
             throw new UserUnauthorizedException();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/RoleServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/RoleServiceImpl.java
@@ -41,7 +41,7 @@ public class RoleServiceImpl implements RoleService{
 
     @Override
     public RoleDTO getRole(RoleWrapper wRole) throws EntityNotFoundException {
-        String name = stringUtil.checkInput(wRole.getName());
+        String name = stringUtil.trimToUpper(wRole.getName());
         Optional<Role> roleData = roleDAO.findByName(name);
         if (roleData.isPresent()) {
             Role role = roleData.get();

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/UserAccessService.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/UserAccessService.java
@@ -11,12 +11,20 @@ import java.util.List;
 
 public interface UserAccessService {
     List<UserDTO> getAllUsers();
-    UserDTO getUser(UserWrapper user) throws UnknownInputException, EntityErrorException;
-    UserDTO createUser(UserWrapper user) throws AuthorizationErrorException, UnknownInputException, EntityErrorException, DatabaseErrorException;
-    UserDTO updateUserPassword(UserWrapper user) throws UnknownInputException, AuthorizationErrorException, EntityErrorException, DatabaseErrorException;
-    UserDTO deleteUser(UserWrapper user) throws UnknownInputException, AuthorizationErrorException, EntityErrorException, DatabaseErrorException;
-    UserDTO addRoles(UserWrapper user) throws AuthorizationErrorException, UnknownInputException, EntityErrorException, DatabaseErrorException;
-    UserDTO removeRoles(UserWrapper user) throws AuthorizationErrorException, UnknownInputException, EntityErrorException, DatabaseErrorException;
-    UserDTO banUser(UserWrapper user) throws UnknownInputException, AuthorizationErrorException, EntityErrorException, DatabaseErrorException;
-    UserDTO unbanUser(UserWrapper user) throws UnknownInputException, AuthorizationErrorException, EntityErrorException, DatabaseErrorException;
+    UserDTO getUser(UserWrapper user)
+            throws UnknownInputException, EntityErrorException;
+    UserDTO createUser(UserWrapper user)
+            throws AuthorizationErrorException, UnknownInputException, EntityErrorException, DatabaseErrorException;
+    UserDTO updateUserPassword(UserWrapper user)
+            throws UnknownInputException, AuthorizationErrorException, EntityErrorException, DatabaseErrorException;
+    UserDTO deleteUser(UserWrapper user)
+            throws UnknownInputException, AuthorizationErrorException, EntityErrorException, DatabaseErrorException;
+    UserDTO addRoles(UserWrapper user)
+            throws AuthorizationErrorException, UnknownInputException, EntityErrorException, DatabaseErrorException;
+    UserDTO removeRoles(UserWrapper user)
+            throws AuthorizationErrorException, UnknownInputException, EntityErrorException, DatabaseErrorException;
+    UserDTO banUser(UserWrapper user)
+            throws UnknownInputException, AuthorizationErrorException, EntityErrorException, DatabaseErrorException;
+    UserDTO unbanUser(UserWrapper user)
+            throws UnknownInputException, AuthorizationErrorException, EntityErrorException, DatabaseErrorException;
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/UserServiceImpl.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/UserServiceImpl.java
@@ -26,10 +26,9 @@ public class UserServiceImpl implements UserDetailsService {
         Optional<User> _userData = userDAO.findByUsername(username);
         if (_userData.isPresent()) {
             User _user = _userData.get();
-            UserDetails userDetails = new org.springframework.security.core.userdetails.User(
+            return new org.springframework.security.core.userdetails.User(
                     _user.getUsername(), _user.getPassword(), getAuthority(_user)
             );
-            return userDetails;
         } else {
             throw new UsernameNotFoundException("User with username: " + username + " not found.");
         }

--- a/src/main/java/com/stargazerstudios/existence/symphony/wrapper/RoleWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/wrapper/RoleWrapper.java
@@ -1,8 +1,12 @@
 package com.stargazerstudios.existence.symphony.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.GetValidation;
 import lombok.*;
+
+import javax.validation.constraints.NotBlank;
 
 @Getter @Setter @NoArgsConstructor
 public class RoleWrapper {
+    @NotBlank(groups = GetValidation.class)
     private String name;
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/wrapper/UserWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/wrapper/UserWrapper.java
@@ -1,13 +1,26 @@
 package com.stargazerstudios.existence.symphony.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.*;
 import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 @Getter @Setter @NoArgsConstructor
 public class UserWrapper {
+    @NotBlank(groups = {
+            PostValidation.class, GetValidation.class, PutValidation.class,
+            PutRelationValidation.class, AuthValidation.class, DeleteValidation.class
+    })
     private String username;
+    @NotBlank(groups = PostValidation.class)
     private String password;
+    @NotBlank(groups = PutValidation.class)
     private String old_password;
+    @NotBlank(groups = PutValidation.class)
     private String new_password;
+    @NotBlank(groups = PutValidation.class)
     private String confirm_password;
+    @NotEmpty(groups = PutRelationValidation.class)
     private String[] roles;
 }


### PR DESCRIPTION
* Added artifact spring-boot-starter-validation on pom.xml to enable Spring's built in validation.
* Created empty interfaces, each corresponding to a REST action. These are used to group the fields to be validated only on certain REST actions.
* Removed an unused import on Symphony's user controller. Why did I miss this on the previous commits? Geez.
* Modified the RestExeptionHandler class. It now overrides Spring's default handler for invalid input fields, allowing the app to throw custom errors back to the end user instead of just using Spring's blank BAD REQUEST error.
* Modified the wrapper and controller classes for the Tag and Story entities to use Spring's built in validation.
* Removed the validation from the custom StringUtil on the service classes of the Tag and Story entities to prevent validation from being redundant. The StringUtil validation on the individual array items have been retained because apparently Spring doesn't handle validation of individual array items.
* Create a new method on the custom StringUtil that will trim String inputs and transform them to uppercase.

* Applied Spring's built in validators to the User and Role entities on Symphony. The Setting entity was not modified because it would be handled by a different commit.
* Created a new class to hold Symphony's database constraint. This is used when catching errors.
* Authentication through third party now catches and throws the correct exception.
* Some Symphony code cleanups here and there that I won't be specifying because I have been working for almost 12 hours now.
* Cleaned the entity wrappers on Ballad. I know, it shouldn't be on this commit but I don't want them to be overlooked.

* Applied Spring's built in validators to the Machine, System, Zone and Event entities on Sonata. The Event Type entity was not modified because its CRUD functions are not yet fully done.

Well, that's it. Quite a small changelog.