### PR TITLE
2022-04-01 Dependency Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.0</version>
+		<version>2.6.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.stargazerstudios</groupId>
@@ -23,37 +23,37 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
-			<version>2.6.4</version>
+			<version>2.6.5</version>
 		</dependency>
 		<!-- Spring Boot Web -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-			<version>2.6.4</version>
+			<version>2.6.5</version>
 		</dependency>
 		<!-- Spring Boot Web Flux -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
-			<version>2.6.4</version>
+			<version>2.6.5</version>
 		</dependency>
 		<!-- Spring Boot Security -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
-			<version>2.6.4</version>
+			<version>2.6.5</version>
 		</dependency>
 		<!-- Spring Boot Validation -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
-			<version>2.6.4</version>
+			<version>2.6.5</version>
 		</dependency>
 		<!-- Liquibase -->
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-            <version>4.8.0</version>
+            <version>4.9.0</version>
         </dependency>
 		<!-- PostgreSQL Driver -->
 		<dependency>
@@ -78,20 +78,20 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<version>2.6.4</version>
+			<version>2.6.5</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- Apache POI -->
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.1.0</version>
+			<version>5.2.2</version>
 		</dependency>
 		<!-- Apache POI OOXML -->
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>5.1.0</version>
+			<version>5.2.2</version>
 		</dependency>
     </dependencies>
 


### PR DESCRIPTION
* Updated Spring Boot Starter Parent from 2.6.0 to 2.6.5
* Updated Spring Boot Data JPA from 2.6.4 to 2.6.5
* Updated Spring Boot Starter Web from 2.6.4 to 2.6.5
* Updated Spring Boot Starter Webflux from 2.6.4 to 2.6.5
* Updated Spring Boot Starter Security from 2.6.4 to 2.6.5
* Updated Spring Boot Starter Test from 2.6.4 to 2.6.5
* Updated Spring Boot Starter Validation from 2.6.4 to 2.6.5
* Updated Liquibase Core from 4.8.0 to 4.9.0
* Updated Apache POI from 5.1.0 to 5.2.2
* Updated Apache POI OOXML from 5.1.0 to 5.2.2