### PR TITLE
Release 0.2-beta_20220401_settings-rework

### DIFF
--- a/src/main/java/com/stargazerstudios/existence/conductor/erratum/system/InvalidSettingException.java
+++ b/src/main/java/com/stargazerstudios/existence/conductor/erratum/system/InvalidSettingException.java
@@ -1,0 +1,15 @@
+package com.stargazerstudios.existence.conductor.erratum.system;
+
+import com.stargazerstudios.existence.conductor.erratum.root.SystemErrorException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidSettingException extends SystemErrorException {
+
+    public InvalidSettingException(String key) {
+        super("The value provided for setting with key: " + key + " is not valid.");
+    }
+
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/com/stargazerstudios/existence/symphony/controller/SettingController.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/controller/SettingController.java
@@ -1,14 +1,21 @@
 package com.stargazerstudios.existence.symphony.controller;
 
+import com.stargazerstudios.existence.conductor.erratum.root.AuthorizationErrorException;
+import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
+import com.stargazerstudios.existence.conductor.erratum.root.SystemErrorException;
+import com.stargazerstudios.existence.conductor.validation.groups.PutValidation;
 import com.stargazerstudios.existence.symphony.dto.SettingDTO;
 import com.stargazerstudios.existence.symphony.service.SettingServiceImpl;
 import com.stargazerstudios.existence.symphony.wrapper.SettingWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 import java.util.List;
 
 @CrossOrigin
@@ -25,17 +32,21 @@ public class SettingController {
     }
 
     @GetMapping("/setting/{type}")
-    public ResponseEntity<List<SettingDTO>> getSettingsByType(@PathVariable("type") String type) throws EntityErrorException {
+    public ResponseEntity<List<SettingDTO>> getSettingsByType(@NotBlank @PathVariable("type") String type)
+            throws EntityErrorException {
         return new ResponseEntity<>(settingService.getSettingsByType(type), HttpStatus.OK);
     }
 
     @GetMapping("/setting/{id}")
-    public ResponseEntity<SettingDTO> getSettingById(@PathVariable("id") long id) throws EntityErrorException {
+    public ResponseEntity<SettingDTO> getSettingById(@Min(1) @PathVariable("id") long id)
+            throws EntityErrorException {
         return new ResponseEntity<>(settingService.getSettingById(id), HttpStatus.OK);
     }
 
     @PutMapping("/setting")
-    public ResponseEntity<SettingDTO> modifySetting(@RequestBody SettingWrapper settingWrapper) throws EntityErrorException {
-        return new ResponseEntity<>(settingService.modifySetting(settingWrapper), HttpStatus.OK);
+    public ResponseEntity<SettingDTO> modifySetting(@Validated(PutValidation.class)
+                                                        @RequestBody SettingWrapper setting)
+            throws EntityErrorException, DatabaseErrorException, AuthorizationErrorException, SystemErrorException {
+        return new ResponseEntity<>(settingService.modifySetting(setting), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/dto/SettingDTO.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/dto/SettingDTO.java
@@ -1,7 +1,6 @@
 package com.stargazerstudios.existence.symphony.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.stargazerstudios.existence.symphony.entity.Setting;
 import lombok.*;
 
 import java.sql.Timestamp;
@@ -21,18 +20,4 @@ public class SettingDTO {
     private String last_changed_by;
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
     private Timestamp last_changed_date;
-
-    public SettingDTO(Setting setting) {
-        setId(setting.getId());
-        setKey(setting.getKey());
-        setValue(setting.getValue());
-        setLength(setting.getLength());
-        setType(setting.getType());
-        setDesc(setting.getDescription());
-        setDefault_value(setting.getDefaultValue());
-        setValid_values(setting.getValidValues());
-        setAdded_by(setting.getAddedBy());
-        setLast_changed_by(setting.getChangedBy());
-        setLast_changed_date(setting.getDateChanged());
-    }
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/service/SettingService.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/service/SettingService.java
@@ -1,6 +1,9 @@
 package com.stargazerstudios.existence.symphony.service;
 
+import com.stargazerstudios.existence.conductor.erratum.root.AuthorizationErrorException;
+import com.stargazerstudios.existence.conductor.erratum.root.DatabaseErrorException;
 import com.stargazerstudios.existence.conductor.erratum.root.EntityErrorException;
+import com.stargazerstudios.existence.conductor.erratum.root.SystemErrorException;
 import com.stargazerstudios.existence.symphony.dto.SettingDTO;
 import com.stargazerstudios.existence.symphony.wrapper.SettingWrapper;
 
@@ -11,5 +14,5 @@ public interface SettingService {
     SettingDTO getSettingById(long id) throws EntityErrorException;
     SettingDTO getSettingByKey(String key) throws EntityErrorException;
     List<SettingDTO> getSettingsByType(String type) throws EntityErrorException;
-    SettingDTO modifySetting(SettingWrapper settingWrapper) throws EntityErrorException;
+    SettingDTO modifySetting(SettingWrapper settingWrapper) throws EntityErrorException, DatabaseErrorException, AuthorizationErrorException, SystemErrorException;
 }

--- a/src/main/java/com/stargazerstudios/existence/symphony/utils/SettingUtil.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/utils/SettingUtil.java
@@ -1,0 +1,40 @@
+package com.stargazerstudios.existence.symphony.utils;
+
+import com.stargazerstudios.existence.conductor.constants.EnumUtilOutput;
+import com.stargazerstudios.existence.symphony.dto.SettingDTO;
+import com.stargazerstudios.existence.symphony.entity.Setting;
+import com.stargazerstudios.existence.symphony.repository.SettingDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class SettingUtil {
+
+    @Autowired
+    private SettingDAO settingDAO;
+
+    public SettingDTO wrapSetting(Setting setting) {
+        SettingDTO settingDTO = new SettingDTO();
+        settingDTO.setId(setting.getId());
+        settingDTO.setKey(setting.getKey());
+        settingDTO.setValue(setting.getValue());
+        settingDTO.setLength(setting.getLength());
+        settingDTO.setType(setting.getType());
+        settingDTO.setDesc(setting.getDescription());
+        settingDTO.setDefault_value(setting.getDefaultValue());
+        settingDTO.setValid_values(setting.getValidValues());
+        settingDTO.setAdded_by(setting.getAddedBy());
+        settingDTO.setLast_changed_by(setting.getChangedBy());
+        settingDTO.setLast_changed_date(setting.getDateChanged());
+
+        return settingDTO;
+    }
+
+    public String getCurrentSetting(String key) {
+        Optional<Setting> settingData = settingDAO.findSettingByKey(key);
+        if (settingData.isEmpty()) return EnumUtilOutput.INVALID.getValue();
+        return settingData.get().getValue();
+    }
+}

--- a/src/main/java/com/stargazerstudios/existence/symphony/wrapper/SettingWrapper.java
+++ b/src/main/java/com/stargazerstudios/existence/symphony/wrapper/SettingWrapper.java
@@ -1,10 +1,15 @@
 package com.stargazerstudios.existence.symphony.wrapper;
 
+import com.stargazerstudios.existence.conductor.validation.groups.PutValidation;
 import lombok.*;
 
-import java.util.HashMap;
+import javax.validation.constraints.NotBlank;
 
 @Getter @Setter @NoArgsConstructor
 public class SettingWrapper {
-    private HashMap<String, String> setting;
+    private long id;
+    @NotBlank(groups = PutValidation.class)
+    private String key;
+    @NotBlank(groups = PutValidation.class)
+    private String value;
 }

--- a/src/main/resources/db/changelog/changes/changelog-v0.1-alpha.xml
+++ b/src/main/resources/db/changelog/changes/changelog-v0.1-alpha.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <!-- Symphony -->
+    <include file="db/changelog/changes/symphony/create-roles-table-changelog-1.xml"/>
+    <include file="db/changelog/changes/symphony/insert-into-roles-table-changelog-11.xml"/>
+    <include file="db/changelog/changes/symphony/create-users-table-changelog-2.xml"/>
+    <include file="db/changelog/changes/symphony/create-settings-table-changelog-3.xml"/>
+    <include file="db/changelog/changes/symphony/insert-into-settings-table-changelog-31.xml"/>
+    <include file="db/changelog/changes/symphony/create-users-roles-table-changelog-4.xml"/>
+
+    <!-- Sonata -->
+    <include file="db/changelog/changes/sonata/create-machines-table-changelog-1.xml"/>
+    <include file="db/changelog/changes/sonata/create-systems-table-changelog-2.xml"/>
+    <include file="db/changelog/changes/sonata/create-zones-table-changelog-3.xml"/>
+    <include file="db/changelog/changes/sonata/create-event-types-table-changelog-4.xml"/>
+    <include file="db/changelog/changes/sonata/insert-into-event-types-table-changelog-41.xml"/>
+    <include file="db/changelog/changes/sonata/create-events-table-changelog-5.xml"/>
+    <include file="db/changelog/changes/sonata/create-events-zones-table-changelog-6.xml"/>
+    <include file="db/changelog/changes/sonata/create-events-event-types-table-changelog-7.xml"/>
+
+    <!-- Ballad -->
+    <include file="db/changelog/changes/ballad/create-stories-table-changelog-1.xml"/>
+    <include file="db/changelog/changes/ballad/create-tags-table-changelog-2.xml"/>
+    <include file="db/changelog/changes/ballad/create-stories-tags-table-changelog-3.xml"/>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/changelog-v0.2-beta.xml
+++ b/src/main/resources/db/changelog/changes/changelog-v0.2-beta.xml
@@ -5,8 +5,6 @@
         xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
-    <!-- v0.1-alpha changelog -->
-    <include file="db/changelog/changes/changelog-v0.1-alpha.xml"/>
-    <!-- v0.2-beta changelog -->
-    <include file="db/changelog/changes/changelog-v0.2-beta.xml"/>
+    <!-- Symphony -->
+    <include file="db/changelog/changes/symphony/insert-into-settings-table-changelog-32.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/symphony/insert-into-settings-table-changelog-32.xml
+++ b/src/main/resources/db/changelog/changes/symphony/insert-into-settings-table-changelog-32.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <property name="now" value="now()" dbms="postgresql"/>
+    <changeSet author="v0.2-beta" id="20220402-032">
+        <comment>Insert settings available since v0.2-beta.</comment>
+        <insert tableName="symphony_settings">
+            <column name="key" value="settingexpliciterror"/>
+            <column name="value" value="N"/>
+            <column name="length" value="1"/>
+            <column name="type" value="B"/>
+            <column name="description" value="Throw error if a setting is attempted to be set to an invalid value instead of defaulting to its default value."/>
+            <column name="default_value" value="N"/>
+            <column name="valid_values" value="Y,N"/>
+            <column name="added_by" value="0.2-beta"/>
+            <column name="changed_by" value="admin"/>
+            <column name="last_changed_date" valueDate="${now}"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
* Created a new custom error to handle invalid setting values.
* Applied Spring's default validation to the Setting entity on Symphony.
* Changed the fields of the Setting entity wrapper from a HashMap to multiple string fields.
* Added a new setting entry on the database to handle the throwing of errors when an invalid value is assigned to a setting.
* Reorganized the changelogs into different files to be more scalable in the future.
* Reworked the process on how the setting entity is wrapped to be in line with the app's standard process.
* Created a new utility class for the setting entity. This will handle the wrapping process that was previously done by the DTO.